### PR TITLE
CustomCraft currentIndex Fix

### DIFF
--- a/SMLHelper/Patchers/TechTypePatcher.cs
+++ b/SMLHelper/Patchers/TechTypePatcher.cs
@@ -13,7 +13,7 @@ namespace SMLHelper.Patchers
 
         private static Dictionary<TechType, string> customTechTypes = new Dictionary<TechType, string>();
 
-        private static int currentIndex = 11011;
+        public static int currentIndex = 11011;
         private static string CallerName = null;
 
         public static TechType AddTechType(string name, string languageName, string languageTooltip)


### PR DESCRIPTION
Fixing the currentIndex to allow changing it individually per item.
This is used to create a custom entry in the customcraft files.
I am just starting to get into coding so if something is wrong, i will try to fix it.

Usage would be like so:
TechTypePatcher.currentIndex = 10001;
(Your added items via the modding helper)

TechTypePatcher.currentIndex = 10002;
(Your added items via the modding helper)