### PR TITLE
SML Helper Default Node Removal

### DIFF
--- a/SMLHelper/CraftNodeScrubber.cs
+++ b/SMLHelper/CraftNodeScrubber.cs
@@ -1,0 +1,14 @@
+﻿namespace SMLHelper
+{    
+    public class CraftNodeScrubber
+    {
+        public CraftScheme Scheme;
+        public string Path;
+
+        public CraftNodeScrubber(CraftScheme scheme, string path)
+        {
+            Scheme = scheme;
+            Path = path;
+        }
+    }
+}

--- a/SMLHelper/CraftNodeToScrub.cs
+++ b/SMLHelper/CraftNodeToScrub.cs
@@ -1,11 +1,11 @@
 ﻿namespace SMLHelper
 {    
-    public class CraftNodeScrubber
+    public class CraftNodeToScrub
     {
         public CraftScheme Scheme;
         public string Path;
 
-        public CraftNodeScrubber(CraftScheme scheme, string path)
+        public CraftNodeToScrub(CraftScheme scheme, string path)
         {
             Scheme = scheme;
             Path = path;

--- a/SMLHelper/Patchers/CraftTreePatcher.cs
+++ b/SMLHelper/Patchers/CraftTreePatcher.cs
@@ -125,6 +125,9 @@ namespace SMLHelper.Patchers
 
         private static void RemoveNodes(ref CraftNode nodes, List<CraftNodeScrubber> nodesToRemove, CraftScheme scheme)
         {
+            // This method can be used to both remove single child nodes, thus removing one recipe from the tree.
+            // Or it can remove entire tabs at once, removing the tab and all the recipes it contained in one go.
+
             foreach (var nodeToRemove in nodesToRemove)
             {
                 // Not for this fabricator. Skip.
@@ -151,7 +154,7 @@ namespace SMLHelper.Patchers
                 // Hold a reference to the parent node
                 var parentNode = currentNode.parent;                
 
-                // Safty checks
+                // Safty checks.
                 if (currentNode != null && currentNode.id == currentPath)
                 {
                     currentNode.Clear(); // Remove all the child nodes to the one to remove

--- a/SMLHelper/Patchers/CraftTreePatcher.cs
+++ b/SMLHelper/Patchers/CraftTreePatcher.cs
@@ -9,7 +9,7 @@ namespace SMLHelper.Patchers
     {
         public static List<CustomCraftTab> customTabs = new List<CustomCraftTab>();
         public static List<CustomCraftNode> customNodes = new List<CustomCraftNode>();
-        public static List<CraftNodeScrubber> nodesToRemove = new List<CraftNodeScrubber>();
+        public static List<CraftNodeToScrub> nodesToRemove = new List<CraftNodeToScrub>();
 
         [Obsolete("CraftTreePatcher.customCraftNodes is obsolete. Use CraftTreePatcher.customNodes", false)]
         public static Dictionary<string, TechType> customCraftNodes = new Dictionary<string, TechType>();
@@ -123,7 +123,7 @@ namespace SMLHelper.Patchers
             }
         }
 
-        private static void RemoveNodes(ref CraftNode nodes, List<CraftNodeScrubber> nodesToRemove, CraftScheme scheme)
+        private static void RemoveNodes(ref CraftNode nodes, List<CraftNodeToScrub> nodesToRemove, CraftScheme scheme)
         {
             // This method can be used to both remove single child nodes, thus removing one recipe from the tree.
             // Or it can remove entire tabs at once, removing the tab and all the recipes it contained in one go.
@@ -157,8 +157,8 @@ namespace SMLHelper.Patchers
                 // Safty checks.
                 if (currentNode != null && currentNode.id == currentPath)
                 {
-                    currentNode.Clear(); // Remove all the child nodes to the one to remove
-                    parentNode.RemoveNode(currentNode); // Remove this node from the parent node
+                    currentNode.Clear(); // Remove all child nodes (if any)
+                    parentNode.RemoveNode(currentNode); // Remove the node
                 }
             }
         }

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -32,13 +32,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\SteamApps\steamapps\common\Subnautica\Subnautica_Data\Managed\0Harmony.dll</HintPath>
+      <HintPath>D:\Github Repos\subnautica-modloader\assemblies\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\SteamApps\steamapps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>D:\Github Repos\subnautica-modloader\assemblies\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\..\..\..\SteamApps\steamapps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>D:\SteamLibrary\steamapps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -47,7 +47,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\SteamApps\steamapps\common\Subnautica\Subnautica_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>D:\Github Repos\subnautica-modloader\assemblies\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -51,6 +51,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CraftNodeScrubber.cs" />
     <Compile Include="CraftScheme.cs" />
     <Compile Include="CustomCraftNode.cs" />
     <Compile Include="CustomCraftTab.cs" />

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -51,7 +51,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="CraftNodeScrubber.cs" />
+    <Compile Include="CraftNodeToScrub.cs" />
     <Compile Include="CraftScheme.cs" />
     <Compile Include="CustomCraftNode.cs" />
     <Compile Include="CustomCraftTab.cs" />

--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -32,13 +32,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>D:\Github Repos\subnautica-modloader\assemblies\0Harmony.dll</HintPath>
+      <HintPath>..\..\..\..\SteamApps\steamapps\common\Subnautica\Subnautica_Data\Managed\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>D:\Github Repos\subnautica-modloader\assemblies\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\SteamApps\steamapps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>D:\SteamLibrary\steamapps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>..\..\..\..\SteamApps\steamapps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -47,7 +47,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>D:\Github Repos\subnautica-modloader\assemblies\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\SteamApps\steamapps\common\Subnautica\Subnautica_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
**This update allows default nodes from the original fabrication trees to be removed during patching.**
A simple use case for this feature is the removing original crafting nodes and then adding them back in as custom nodes in a new hierarchy. This can be helpful when there are so many sibling nodes that they can't all be displayed on screen at once.

**To stage nodes for removal:**
1. Create a new instance of the ```CraftNodeToScrub``` class which has you specify to which fabrication scheme the node belongs to and the path to it. 
2. Add the new CraftNodeToScrub to the public static list field ```nodesToRemove``` now added to ```CraftTreePatcher```
3. The ```RemoveNodes``` method will be called during patching, removing the requested node from the crafting tree.

This feature works _both_ on recipe nodes _and_ tab nodes.
When removing a tab node, all child nodes to it are also removed.