### PR TITLE
- Updated project setting to build XML Documentation file.

### DIFF
--- a/SMLHelper/SMLHelper.csproj
+++ b/SMLHelper/SMLHelper.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\SMLHelper.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
- This file allows the XML documentation we write to be visible to other projects that reference SMLHelper by DLL.
- For external projects using SMLHelper, the file "SMLHelper.xml" only needs to be in the same directory where SMLHelper.dll is being referenced from.

References:
https://stackoverflow.com/questions/1632942/how-do-you-get-xml-comments-to-appear-in-a-different-project-dll
https://docs.microsoft.com/en-us/dotnet/csharp/codedoc
