### PR TITLE
2.0 Legacy CraftTreePatcher Fix

### DIFF
--- a/SMLHelper/Legacy/Patchers/CraftTreePatcher.cs
+++ b/SMLHelper/Legacy/Patchers/CraftTreePatcher.cs
@@ -25,105 +25,96 @@
 
         internal static void Patch()
         {
-            var nodes = new List<CustomCraftNode>();
-
-            foreach (var customNode in customNodes)
-                nodes.Add(new CustomCraftNode(customNode.TechType, customNode.Scheme, customNode.Path));
-
-            foreach (var customNode in customCraftNodes)
-                nodes.Add(new CustomCraftNode(customNode.Value, CraftTree.Type.Fabricator, customNode.Key));
-
-            foreach(var tab in customTabs)
+            // Old custom tabs added through new CustomCraftTreeNode classes
+            foreach (var tab in customTabs)
             {
                 if (tab == null) continue;
 
-                var path = tab.Path.SplitByChar('/');
-                var tree = CraftTreeHandler.GetExistingTree(tab.Scheme);
+                var root = CraftTreeHandler.GetExistingTree(tab.Scheme);
 
-                if (tree == null) continue;
+                if (root == null) continue;
 
-                var tabNode = default(CustomCraftTreeTab);
-
-                foreach (var pathNode in path)
+                if (!tab.Path.Contains("/")) // Added to the root
                 {
-                    var newTabNode = default(CustomCraftTreeTab);
+                    root.AddTabNode(tab.Path, tab.Name, tab.Sprite.Sprite);
+                }
+                else // Added under an existing tab
+                {
+                    var path = tab.Path.SplitByChar('/');
+                    CustomCraftTreeTab node = root.GetTabNode(path[0]);
 
-                    if (tabNode == null)
-                        newTabNode = tree.GetTabNode(pathNode);
-                    else
-                        newTabNode = tabNode.GetTabNode(pathNode);
+                    for (int i = 1; i < path.Length - 1; i++)
+                    {
+                        node = node.GetTabNode(path[i]);
+                    }
 
-                    if (newTabNode == null)
-                        tabNode.AddTabNode(pathNode, tab.Name, tab.Sprite.Sprite);
-                    else
-                        tabNode = newTabNode;
+                    var tabName = path[path.Length - 1]; // Last
+                    node.AddTabNode(tabName, tab.Name, tab.Sprite.Sprite);
                 }
             }
 
-            foreach(var node in nodes)
+            // Old custom craft nodes added through new CustomCraftTreeNode classes
+
+            var craftNodes = new List<CustomCraftNode>();
+
+            foreach (var customNode in customNodes)
+                craftNodes.Add(new CustomCraftNode(customNode.TechType, customNode.Scheme, customNode.Path));
+
+            foreach (var customNode in customCraftNodes)
+                craftNodes.Add(new CustomCraftNode(customNode.Value, CraftTree.Type.Fabricator, customNode.Key));
+
+            foreach (var craftNode in craftNodes)
             {
-                if (node == null) continue;
+                if (craftNode == null) continue;
 
-                var path = node.Path.SplitByChar('/');
-                var tree = CraftTreeHandler.GetExistingTree(node.Scheme);
+                var root = CraftTreeHandler.GetExistingTree(craftNode.Scheme);
 
-                if (tree == null) continue;
+                if (root == null) continue;
 
-                var tabNode = default(CustomCraftTreeTab);
-
-                foreach(var pathNode in path)
+                if (!craftNode.Path.Contains("/")) // Added to the root
                 {
-                    var newTabNode = default(CustomCraftTreeTab);
+                    root.AddCraftingNode(craftNode.TechType);
+                }
+                else // Added under an existing tab
+                {
+                    var path = craftNode.Path.SplitByChar('/');
+                    CustomCraftTreeTab node = root.GetTabNode(path[0]);
 
-                    if (tabNode == null)
-                        newTabNode = tree.GetTabNode(pathNode);
-                    else
-                        newTabNode = tabNode.GetTabNode(pathNode);
-
-                    if (newTabNode == null && tabNode != null)
+                    for (int i = 1; i < path.Length - 1; i++)
                     {
-                        var techType = TechType.None;
-                        var craftNode = default(CustomCraftTreeCraft);
+                        node = node.GetTabNode(path[i]);
+                    }
 
-                        if(TechTypeExtensions.FromString(pathNode, out techType, false))
-                        {
-                            craftNode = tabNode.AddCraftingNode(techType);
-                        }
-                        else
-                        {
-                            craftNode = tabNode.AddModdedCraftingNode(pathNode);
-                        }
-                    }
-                    else
-                    {
-                        tabNode = newTabNode;
-                    }
+                    var tabName = path[path.Length - 1]; // Last
+                    node.AddCraftingNode(node.TechType);
                 }
             }
 
-            foreach (var node in nodesToRemove)
+            // Old node scrubbing handled through new CustomCraftTreeNode classes
+            foreach (var scrubNode in nodesToRemove)
             {
-                if (node == null) continue;
+                if (scrubNode == null) continue;
 
-                var path = node.Path.SplitByChar('/');
-                var tree = CraftTreeHandler.GetExistingTree(node.Scheme);
+                var root = CraftTreeHandler.GetExistingTree(scrubNode.Scheme);
 
-                if (tree == null) continue;
+                if (root == null) continue;
 
-                var treeNode = default(CustomCraftTreeNode);
-
-                foreach (var pathNode in path)
+                if (!scrubNode.Path.Contains("/")) // Removed from the root
                 {
-                    var newTreeNode = tree.GetNode(pathNode);
+                    root.GetNode(scrubNode.Path).RemoveNode();
+                }
+                else // Removed from an existing tab
+                {
+                    var path = scrubNode.Path.SplitByChar('/');
+                    CustomCraftTreeTab node = root.GetTabNode(path[0]);
 
-                    if(newTreeNode == null)
+                    for (int i = 1; i < path.Length - 1; i++)
                     {
-                        treeNode.RemoveNode();
+                        node = node.GetTabNode(path[i]);
                     }
-                    else
-                    {
-                        treeNode = newTreeNode;
-                    }
+
+                    var tabName = path[path.Length - 1]; // Last
+                    node.RemoveNode();
                 }
             }
 


### PR DESCRIPTION
 Reworked the Old CraftTreePatcher logic to work with the new form of handling CraftTree overrides that combine fully custom trees and modded trees in the same framework.