### PR TITLE
2.0 add group add after

### DIFF
--- a/SMLHelper/Handlers/CraftDataHandler.cs
+++ b/SMLHelper/Handlers/CraftDataHandler.cs
@@ -149,7 +149,20 @@
         /// <param name="techType">The TechType you want to add.</param>
         public static void AddToGroup(TechGroup group, TechCategory category, TechType techType)
         {
-            CraftDataPatcher.AddToCustomGroup(group, category, techType);
+            CraftDataPatcher.AddToCustomGroup(group, category, techType, TechType.None);
+        }
+
+        /// <summary>
+        /// Allows you to add items to the game's internal grouping system.
+        /// Required if you want to make buildable items show up in the Habitat Builder.
+        /// </summary>
+        /// <param name="group">The TechGroup you want to add your TechType to.</param>
+        /// <param name="category">The TechCategory (in the TechGroup) you want to add your TechType to.</param>
+        /// <param name="techType">The TechType you want to add.</param>
+        /// <param name="after">Added TechType will be added after this TechType, for sorting purposes.</param>
+        public static void AddToGroup(TechGroup group, TechCategory category, TechType techType, TechType after)
+        {
+            CraftDataPatcher.AddToCustomGroup(group, category, techType, after);
         }
 
         /// <summary>

--- a/SMLHelper/Legacy/Patchers/CraftDataPatcher.cs
+++ b/SMLHelper/Legacy/Patchers/CraftDataPatcher.cs
@@ -31,7 +31,7 @@ namespace SMLHelper.Patchers
         [Obsolete("Use SMLHelper.V2 instead.")]
         public static void AddToCustomGroup(TechGroup group, TechCategory category, TechType techType)
         {
-            CraftDataPatcher2.AddToCustomGroup(group, category, techType);
+            CraftDataPatcher2.AddToCustomGroup(group, category, techType, TechType.None);
         }
 
         [Obsolete("Use SMLHelper.V2 instead.")]

--- a/SMLHelper/Patchers/CraftDataPatcher.cs
+++ b/SMLHelper/Patchers/CraftDataPatcher.cs
@@ -53,14 +53,15 @@
                 return;
             }
 
-            if(after == TechType.None)
+            int index = techCategory.IndexOf(after);
+
+            if(index == -1) // Not found
             {
                 techCategory.Add(techType);
                 Logger.Log($"Added \"{techType.AsString():G}\" to groups under \"{group:G}->{category:G}\"");
             }
             else
-            { 
-                int index = techCategory.IndexOf(after);
+            {
                 techCategory.Insert(index + 1, techType);
 
                 Logger.Log($"Added \"{techType.AsString():G}\" to groups under \"{group:G}->{category:G}\" after \"{after.AsString():G}\"");

--- a/SMLHelper/Patchers/CraftDataPatcher.cs
+++ b/SMLHelper/Patchers/CraftDataPatcher.cs
@@ -35,11 +35,11 @@
 
         #region Group Handling
 
-        internal static void AddToCustomGroup(TechGroup group, TechCategory category, TechType techType)
+        internal static void AddToCustomGroup(TechGroup group, TechCategory category, TechType techType, TechType after)
         {
             var groups = GroupsField.GetValue(null) as Dictionary<TechGroup, Dictionary<TechCategory, List<TechType>>>;
             var techGroup = groups[group];
-            if(techGroup == null)
+            if (techGroup == null)
             {
                 // Should never happen, but doesn't hurt to add it.
                 Logger.Log("Invalid TechGroup!");
@@ -47,15 +47,24 @@
             }
 
             var techCategory = techGroup[category];
-            if(techCategory == null)
+            if (techCategory == null)
             {
                 Logger.Log($"Invalid TechCategory Combination! TechCategory: {category} TechGroup: {group}");
                 return;
             }
 
-            techCategory.Add(techType);
+            if(after == TechType.None)
+            {
+                techCategory.Add(techType);
+                Logger.Log($"Added \"{techType.AsString():G}\" to groups under \"{group:G}->{category:G}\"");
+            }
+            else
+            { 
+                int index = techCategory.IndexOf(after);
+                techCategory.Insert(index + 1, techType);
 
-            Logger.Log($"Added \"{techType.AsString():G}\" to groups under \"{group:G}->{category:G}\"");
+                Logger.Log($"Added \"{techType.AsString():G}\" to groups under \"{group:G}->{category:G}\" after \"{after.AsString():G}\"");
+            }
         }
 
         internal static void RemoveFromCustomGroup(TechGroup group, TechCategory category, TechType techType)


### PR DESCRIPTION
### Changes made in this pull request

  - CraftDataPatcher.AddToCustomGroup now takes in a fourth parameter called `after` of type `TechType`
  - Instead of calling `techCategory.Add(techType)`, it calls `techCategory.Insert`, based on the index of the `after` parameter. 
  - The `after` parameter is optional, and the API has 2 overloads for AddToGroup: the first overload takes in nothing (so it will work as it did before) and the second overload takes in the, you guessed it, `after` parameter.
