### PR TITLE
 SpriteManager_NoGet

### DIFF
--- a/SMLHelper/Assets/ModSprite.cs
+++ b/SMLHelper/Assets/ModSprite.cs
@@ -1,5 +1,6 @@
 ﻿namespace SMLHelper.V2.Assets
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -7,7 +8,22 @@
     /// </summary>
     internal class ModSprite
     {
-        internal static List<ModSprite> Sprites = new List<ModSprite>();
+        internal static void Add(SpriteManager.Group group, string name, Atlas.Sprite sprite)
+        {
+            if (group == SpriteManager.Group.None)
+                group = SpriteManager.Group.Item;
+            // Using Item instead of None is necessary as this is the typical group the game will call.
+
+            if (!ModSprites.ContainsKey(group))
+                ModSprites.Add(group, new Dictionary<string, Atlas.Sprite>(StringComparer.InvariantCultureIgnoreCase));
+
+            ModSprites[group][name] = sprite;
+        }
+
+        internal static void Add(ModSprite sprite) => Add(sprite.Group, sprite.Id, sprite.Sprite);
+
+        internal static Dictionary<SpriteManager.Group, Dictionary<string, Atlas.Sprite>> ModSprites 
+            = new Dictionary<SpriteManager.Group, Dictionary<string, Atlas.Sprite>>();
 
         /// <summary>
         /// The tech type of a specific item associated with this sprite.
@@ -40,8 +56,9 @@
         public ModSprite(TechType type, Atlas.Sprite sprite)
         {
             TechType = type;
+            Id = type.AsString();
             Sprite = sprite;
-            Group = SpriteManager.Group.None;
+            Group = SpriteManager.Group.Item;
         }
 
         /// <summary>
@@ -57,6 +74,21 @@
             Id = id;
             Sprite = sprite;
             TechType = TechType.None;
+        }
+
+        /// <summary>
+        /// Creates a new ModSprite to be used with a specific group and internal ID.
+        /// Created with an Atlas Sprite.
+        /// </summary>
+        /// <param name="group">The sprite group.</param>
+        /// <param name="type">The techtype paired to this sprite.</param>
+        /// <param name="sprite">The sprite to be added.</param>
+        public ModSprite(SpriteManager.Group group, TechType type, Atlas.Sprite sprite)
+        {
+            Group = group;
+            Id = type.AsString();
+            Sprite = sprite;
+            TechType = type;
         }
 
         /// <summary>

--- a/SMLHelper/Assets/ModSprite.cs
+++ b/SMLHelper/Assets/ModSprite.cs
@@ -12,7 +12,8 @@
         {
             if (group == SpriteManager.Group.None)
                 group = SpriteManager.Group.Item;
-            // Using Item instead of None is necessary as this is the typical group the game will call.
+            // There are no calls for sprites in the None Group.
+            // All sprite calls for almost anything we don't manually group is in the Item group.
 
             if (!ModSprites.ContainsKey(group))
                 ModSprites.Add(group, new Dictionary<string, Atlas.Sprite>(StringComparer.InvariantCultureIgnoreCase));

--- a/SMLHelper/Crafting/ModCraftTreeFamily.cs
+++ b/SMLHelper/Crafting/ModCraftTreeFamily.cs
@@ -2,8 +2,8 @@
 {
     using System.Collections.Generic;
     using System.Linq;
-    using Patchers;
     using Assets;
+    using Patchers;
     using UnityEngine;
     using UnityEngine.Assertions;
     using Utility;
@@ -411,9 +411,10 @@
             else
             {
                 modSprite = new ModSprite(SpriteManager.Group.Category, spriteID, Usprite);
+
             }
 
-            ModSprite.Sprites.Add(modSprite);
+            ModSprite.Add(modSprite);
         }
     }
 

--- a/SMLHelper/Crafting/NodeFamily.cs
+++ b/SMLHelper/Crafting/NodeFamily.cs
@@ -37,7 +37,7 @@
             DisplayName = displayName;
             Name = name;
 
-            ModSprite.Sprites.Add(new ModSprite(SpriteManager.Group.Category, $"{Scheme.ToString()}_{Name}", Sprite));
+            ModSprite.Add(new ModSprite(SpriteManager.Group.Category, $"{Scheme.ToString()}_{Name}", Sprite));
             LanguagePatcher.customLines[$"{Scheme.ToString()}Menu_{Name}"] = DisplayName;
         }
     }

--- a/SMLHelper/Handlers/SpriteHandler.cs
+++ b/SMLHelper/Handlers/SpriteHandler.cs
@@ -16,7 +16,7 @@
         /// <param name="sprite">The sprite to be added.</param>
         public static void RegisterSprite(TechType type, Atlas.Sprite sprite)
         {
-            ModSprite.Sprites.Add(new ModSprite(type, sprite));
+            ModSprite.Add(SpriteManager.Group.None, type.AsString(), sprite);
         }
 
         /// <summary>
@@ -27,7 +27,7 @@
         /// <param name="sprite">The sprite to be added.</param>
         public static void RegisterSprite(SpriteManager.Group group, string id, Atlas.Sprite sprite)
         {
-            ModSprite.Sprites.Add(new ModSprite(group, id, sprite));
+            ModSprite.Add(group, id, sprite);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@
         /// <param name="sprite">The sprite to be added.</param>
         public static void RegisterSprite(SpriteManager.Group group, string id, Sprite sprite)
         {
-            ModSprite.Sprites.Add(new ModSprite(group, id, sprite));
+            ModSprite.Add(group, id, new Atlas.Sprite(sprite));
         }
 
         /// <summary>
@@ -48,7 +48,7 @@
         /// <param name="sprite">The sprite to be added.</param>
         public static void RegisterSprite(TechType type, Sprite sprite)
         {
-            ModSprite.Sprites.Add(new ModSprite(type, sprite));
+            ModSprite.Add(SpriteManager.Group.None, type.AsString(), new Atlas.Sprite(sprite));
         }
 
         /// <summary>

--- a/SMLHelper/Handlers/TechTypeHandler.cs
+++ b/SMLHelper/Handlers/TechTypeHandler.cs
@@ -57,7 +57,7 @@
 
             // Register the Sprite
             if(sprite != null)
-                ModSprite.Sprites.Add(new ModSprite(techType, sprite));
+                ModSprite.Add(SpriteManager.Group.None, internalName, sprite);
 
             // Return the new TechType
             return techType;
@@ -79,7 +79,7 @@
 
             // Register the Sprite
             if (sprite != null)
-                ModSprite.Sprites.Add(new ModSprite(techType, sprite));
+                ModSprite.Add(SpriteManager.Group.None, internalName, new Atlas.Sprite(sprite));
 
             // Return the new TechType
             return techType;

--- a/SMLHelper/Initializer.cs
+++ b/SMLHelper/Initializer.cs
@@ -56,7 +56,7 @@ namespace SMLHelper.V2
             LanguagePatcher.Patch(harmony);
             ResourcesPatcher.Patch(harmony);
             PrefabDatabasePatcher.Patch(harmony);
-            SpritePatcher.Patch(harmony);
+            SpritePatcher.Patch();
             KnownTechPatcher.Patch(harmony);
             BioReactorPatcher.Patch(harmony);
             OptionsPanelPatcher.Patch(harmony);

--- a/SMLHelper/Legacy/CustomSpriteHandler.cs
+++ b/SMLHelper/Legacy/CustomSpriteHandler.cs
@@ -12,7 +12,7 @@ namespace SMLHelper
 
         internal static void Patch()
         {
-            customSprites.ForEach(x => ModSprite.Sprites.Add(x.GetModSprite()));
+            customSprites.ForEach(x => ModSprite.Add(x.GetModSprite()));
         }
     }
 
@@ -27,7 +27,9 @@ namespace SMLHelper
 
         public CustomSprite(TechType type, Atlas.Sprite sprite)
         {
+            Group = SpriteManager.Group.None;
             TechType = type;
+            Id = type.AsString();
             Sprite = sprite;
         }
 
@@ -36,7 +38,6 @@ namespace SMLHelper
             Group = group;
             Id = id;
             Sprite = sprite;
-
             TechType = TechType.None;
         }
 

--- a/SMLHelper/Patchers/SpritePatcher.cs
+++ b/SMLHelper/Patchers/SpritePatcher.cs
@@ -1,8 +1,9 @@
 ﻿namespace SMLHelper.V2.Patchers
 {
-    using Harmony;
+    using System.Collections.Generic;
     using System.Reflection;
     using Assets;
+    using Harmony;
 
     internal class SpritePatcher
     {
@@ -17,24 +18,20 @@
             Logger.Log("SpritePatcher is done.");
         }
 
-        internal static bool Prefix(ref Atlas.Sprite __result, string name)
+        internal static bool Prefix(ref Atlas.Sprite __result, SpriteManager.Group group, string name)
         {
-            foreach (var sprite in ModSprite.Sprites)
-            {
-                if (sprite.TechType.AsString(true) == name.ToLowerInvariant())
-                {
-                    __result = sprite.Sprite;
-                    return false;
-                }
-                else if(sprite.TechType == TechType.None && sprite.Id.ToLowerInvariant() == name.ToLowerInvariant())
-                {
-                    __result = sprite.Sprite;
-                    return false;
-                }
-            }
+            if (!ModSprite.ModSprites.ContainsKey(group))
+                return true;
 
-            return true;
+            Logger.Log($"Get Sprite Call {group}:{name}.");
+
+            Dictionary<string, Atlas.Sprite> modGroup = ModSprite.ModSprites[group];
+
+            if (!modGroup.ContainsKey(name))
+                return true;
+
+            __result = modGroup[name];
+            return false;
         }
-
     }
 }

--- a/SMLHelper/Patchers/SpritePatcher.cs
+++ b/SMLHelper/Patchers/SpritePatcher.cs
@@ -3,35 +3,26 @@
     using System.Collections.Generic;
     using System.Reflection;
     using Assets;
-    using Harmony;
 
     internal class SpritePatcher
     {
-        internal static void Patch(HarmonyInstance harmony)
+        internal static void Patch()
         {
-            var spriteManager = typeof(SpriteManager);
-            var getFromResources = spriteManager.GetMethod("GetFromResources", BindingFlags.Public | BindingFlags.Static);
+            FieldInfo groupsField = typeof(SpriteManager).GetField("groups", BindingFlags.Static | BindingFlags.NonPublic);
 
-            harmony.Patch(getFromResources,
-                new HarmonyMethod(typeof(SpritePatcher).GetMethod("Prefix", BindingFlags.Static | BindingFlags.NonPublic)), null);
+            var groups = (Dictionary<SpriteManager.Group, Dictionary<string, Atlas.Sprite>>)groupsField.GetValue(null);
+
+            foreach (SpriteManager.Group moddedGroup in ModSprite.ModSprites.Keys)
+            {
+                Dictionary<string, Atlas.Sprite> spriteGroup = groups[moddedGroup];
+
+                foreach (string spriteKey in ModSprite.ModSprites[moddedGroup].Keys)
+                {
+                    spriteGroup.Add(spriteKey, ModSprite.ModSprites[moddedGroup][spriteKey]);
+                }
+            }
 
             Logger.Log("SpritePatcher is done.");
-        }
-
-        internal static bool Prefix(ref Atlas.Sprite __result, SpriteManager.Group group, string name)
-        {
-            if (!ModSprite.ModSprites.ContainsKey(group))
-                return true;
-
-            Logger.Log($"Get Sprite Call {group}:{name}.");
-
-            Dictionary<string, Atlas.Sprite> modGroup = ModSprite.ModSprites[group];
-
-            if (!modGroup.ContainsKey(name))
-                return true;
-
-            __result = modGroup[name];
-            return false;
         }
     }
 }


### PR DESCRIPTION
- SpritePatcher no longer needs to patch the Get methods.
- The modded sprites are loaded directly into the dictionary where they will be loaded from.
- This should improve performance on screens with lots of sprite request calls